### PR TITLE
Satzung: Fördermitgliedschaft reparieren

### DIFF
--- a/Satzung.tex
+++ b/Satzung.tex
@@ -116,7 +116,7 @@
   \item Die Mitgliederversammlung ist mindestens einmal jährlich einzuberufen.
   \item Eine Mitgliederversammlung ist außerdem einzuberufen, wenn es das
     Vereinsinteresse erfordert, oder wenn die Einberufung von mindestens 23\%
-    der Vereinsmitglieder in Textform und unter Angabe des Zweckes und der
+    der ordentlichen Vereinsmitglieder in Textform und unter Angabe des Zweckes und der
     Gründe verlangt wird.
   \item Die Einberufung der Mitgliederversammlung erfolgt in Textform durch den
     Vorstand unter Wahrung einer Einladungsfrist von mindestens 2~Wochen bei
@@ -147,7 +147,7 @@
     \end{itemize}
   \item Die Mitgliederversammlung gibt sich bei Bedarf eine Geschäftsordnung.
   \item Jede satzungsmäßig einberufene Mitgliederversammlung wird als
-    beschlussfähig anerkannt, sofern mindestens 23\% der Mitglieder anwesend
+    beschlussfähig anerkannt, sofern mindestens 23\% der ordentlichen Mitglieder anwesend
     sind. Falls dieser geforderte Anteil nicht erreicht wird, ist die darauf
     folgende Mitgliederversammlung unabhängig von der Anzahl der erschienen
     Mitglieder beschlussfähig. Auf diesen Umstand muss in der Einladung zur
@@ -155,7 +155,7 @@
     Mitglied hat eine Stimme. Fördermitglieder sind berechtigt, an den
     Versammlungen ohne Stimmrecht teilzunehmen.
   \item Die Mitgliederversammlung fasst ihre Beschlüsse mit einfacher Mehrheit
-    der anwesenden Mitglieder, sofern in dieser Satzung nicht anders geregelt.
+    der anwesenden stimmberechtigten Mitglieder, sofern in dieser Satzung nicht anders geregelt.
     Bei Stimmengleichheit gilt ein Antrag als abgelehnt.
   \item Die Ausübung des Stimmrechts auf der Mitgliederversammlung ist nur 
     möglich, wenn bis zum Zeitpunkt der Inanspruchnahme des e.~g. Rechts


### PR DESCRIPTION
Die Fördermitgliedschaft war von Anfang an für Mitglieder gedacht, die den Verein vorrangig finanziell unterstützen wollen und an Abstimmungen auf Mitgliederversammlungen kein Interesse haben (s. §4, Abs 2). Leider wurde bei der entsprechenden Satzungsänderung auf der [Mitgliederversammlung 2013-12-07][1], die die Fördermitgliedschaft einführte, einige Formulierungen nicht angepasst.  So zählen Fördermitglieder bisher noch zum Quorum der Beschlussfähigkeit bei Mitgliederversammlungen, und in andere Quoren, bei denen sie schon jetzt gar kein Stimmrecht haben.  
[1]: https://stratum0.org/mediawiki/index.php?title=Datei:Mitgliederversammlung_2013-12-07.pdf&page=5
