### PR TITLE
Satzung: Wechsel der Art der Mitgliedschaft vereinfachen

### DIFF
--- a/Satzung.tex
+++ b/Satzung.tex
@@ -82,7 +82,7 @@
   \item Die Mitgliedschaft endet durch Austrittserklärung, durch Ausschluss,
     durch Tod von natürlichen Personen oder durch Auflösung und Erlöschung von
     juristischen Personen.
-  \item Ein Austritt oder ein Wechsel der Art der Mitgliedschaft ist jederzeit möglich und wird durch Willenserklärung in
+  \item Ein Austritt oder ein Wechsel der Art der Mitgliedschaft ist jederzeit möglich, und wird durch Willenserklärung in
     Textform gegenüber dem Vorstand vollzogen.
   \item Wenn ein Mitglied gegen die Ziele und Interessen des Vereins schwer
     verstoßen hat oder trotz Mahnung mit dem Beitrag für 3~Monate im Rückstand

--- a/Satzung.tex
+++ b/Satzung.tex
@@ -82,7 +82,7 @@
   \item Die Mitgliedschaft endet durch Austrittserklärung, durch Ausschluss,
     durch Tod von natürlichen Personen oder durch Auflösung und Erlöschung von
     juristischen Personen.
-  \item Ein Austritt ist jederzeit möglich und wird durch Willenserklärung in
+  \item Ein Austritt oder ein Wechsel der Art der Mitgliedschaft ist jederzeit möglich und wird durch Willenserklärung in
     Textform gegenüber dem Vorstand vollzogen.
   \item Wenn ein Mitglied gegen die Ziele und Interessen des Vereins schwer
     verstoßen hat oder trotz Mahnung mit dem Beitrag für 3~Monate im Rückstand


### PR DESCRIPTION
Da die Satzung bisher keinen Wechsel der Art der Mitgliedschaft vorsieht (z.B. von ordentlicher zu Fördermitgliedschaft), wird dieser Vorgang vorstandsintern bisher als Aus- und Wiedereintritt behandelt, was (wegen des Wiedereintritts) zwingend eine Vorstandsentscheidung mit Abstimmung voraussetzt. Um die Situation für den Vorstand zu vereinfachen, kann diese Abstimmung im Prinzip entfallen, da das Mitglied ja weiterhin Mitglied bleibt. Es gibt hier für den Vorstand auch keinen sinnvollen Grund, einen solchen Antrag abzulehnen — das Mitglied sollte selbst am besten wissen, welches Modell sich am besten eignet.
