### PR TITLE
Satzung: Stimmrecht bei Änderung des Vereinszwecks auf ordentliche Mitglieder einschränken

### DIFF
--- a/Satzung.tex
+++ b/Satzung.tex
@@ -225,7 +225,7 @@
     Tagesordnungspunkt bereits in der Einladung zur Mitgliederversammlung
     hingewiesen wurde und der Einladung sowohl der bisherige als auch der
     vorgesehene neue Satzungstext beigefügt wurde.
-  \item Zur Änderung des Vereinszwecks ist die Zweidrittel-Mehrheit aller
+  \item Zur Änderung des Vereinszwecks ist die Zweidrittel-Mehrheit aller ordentlichen
     Vereinsmitglieder erforderlich, wobei die Zustimmung der nicht anwesenden
     Mitglieder per Textform erfolgen kann.
   \item Satzungsänderungen, die von Aufsichts-, Gerichts- oder Finanzbehörden


### PR DESCRIPTION
Analog zu den übrigen Regelungen des Stimmrechts. Teil von #17, alternative Auswahl zu #19.