### PR TITLE
Satzung: Fördermitglieder haben je eine Stimme bei Änderung des Vereinszwecks

### DIFF
--- a/Satzung.tex
+++ b/Satzung.tex
@@ -227,7 +227,8 @@
     vorgesehene neue Satzungstext beigefügt wurde.
   \item Zur Änderung des Vereinszwecks ist die Zweidrittel-Mehrheit aller
     Vereinsmitglieder erforderlich, wobei die Zustimmung der nicht anwesenden
-    Mitglieder per Textform erfolgen kann.
+    Mitglieder per Textform erfolgen kann. Fördermitglieder haben hierbei,
+    abweichend von den übrigen Bestimmungen dieser Satzung, je eine Stimme.
   \item Satzungsänderungen, die von Aufsichts-, Gerichts- oder Finanzbehörden
     aus formalen Gründen verlangt werden, kann der Vorstand von sich aus
     vornehmen. Diese Satzungsänderungen müssen allen Vereinsmitgliedern


### PR DESCRIPTION
Da Fördermitglieder vermutlich hauptsächlich den Zweck des Vereins unterstützen wollen, sollten sie auch bei Änderung des Zwecks ein Mitspracherecht haben. Da die Zustimmung auch per Textform eingeholt werden kann, sollte dies kein Problem für ein Quorum darstellen.

Teil von #17, alternative Auswahl zu #18.