### PR TITLE
Satzung: Übertragung der Mitgliederrechte auf Repräsentanten

### DIFF
--- a/Satzung.tex
+++ b/Satzung.tex
@@ -148,7 +148,7 @@
   \item Die Mitgliederversammlung gibt sich bei Bedarf eine Geschäftsordnung.
   \item Jede satzungsmäßig einberufene Mitgliederversammlung wird als
     beschlussfähig anerkannt, sofern mindestens 23\% der Mitglieder anwesend
-    sind. Falls dieser geforderte Anteil nicht erreicht wird, ist die darauf
+    sind oder durch Repräsentanten repräsentiert werden. Falls dieser geforderte Anteil nicht erreicht wird, ist die darauf
     folgende Mitgliederversammlung unabhängig von der Anzahl der erschienen
     Mitglieder beschlussfähig. Auf diesen Umstand muss in der Einladung zur
     Mitgliederversammlung besonders hingewiesen werden. Jedes ordentliche
@@ -161,6 +161,19 @@
     möglich, wenn bis zum Zeitpunkt der Inanspruchnahme des e.~g. Rechts
     alle offenen Mitgliedsbeiträge des entsprechenden Mitglieds beglichen
     wurden.
+  \item Bei Nichtanwesenheit auf der Mitgliederversammlung kann ein Mitglied
+    seine Mitgliederrechte auf eine andere Person (Repräsentant) übertragen.
+    Die Repräsentanten üben die Mitgliederversammlung betreffend in allen
+    Belangen die Rechte und Pflichten des Mitglieds aus, das durch sie vertreten
+    wird, und sind dementsprechend im Rahmen der Mitgliederversammlung wie
+    Mitglieder im Sinne dieser Satzung zu behandeln.
+    Dabei darf ein Repräsentant zu keiner Zeit mehr als ein Mitglied
+    vertreten. Falls ein Mitglied als Repräsentant benannt wird, werden
+    dessen Rechte als Mitglied dadurch nicht eingeschränkt, in diesem Fall kann
+    ein Mitglied also bis zu zwei Mitglieder, inkl. sich selbst, repräsentieren.
+    Die Übertragung der Mitgliederrechte ist dem Vorstand vom entsprechenden
+    Mitglied spätestens bis zu Beginn der Versammlung in Schriftform bekannt
+    zu machen, wobei der Repräsentant namentlich benannt werden muss.
 \end{enumerate}
 
 \section{Der Vorstand}

--- a/Satzung.tex
+++ b/Satzung.tex
@@ -162,7 +162,8 @@
     alle offenen Mitgliedsbeiträge des entsprechenden Mitglieds beglichen
     wurden.
   \item Bei Nichtanwesenheit auf der Mitgliederversammlung kann ein Mitglied
-    seine Mitgliederrechte auf eine andere Person (Repräsentant) übertragen.
+    seine Mitgliederrechte für die Dauer der Versammlung auf eine andere Person
+    (Repräsentant) übertragen.
     Die Repräsentanten üben die Mitgliederversammlung betreffend in allen
     Belangen die Rechte und Pflichten des Mitglieds aus, das durch sie vertreten
     wird, und sind dementsprechend im Rahmen der Mitgliederversammlung wie


### PR DESCRIPTION
Die Übertragung des Stimmrechts von Mitgliedern kam auf vergangenen Versammlungen vor und wurde dort informell behandelt, wird sich aber auch in Zukunft nicht vermeiden lassen. Daher sollte die Satzung diesen Fall vorsehen.

Anmerkungen:
- Repräsentant ist wie Mitglied zu behandeln, zählt also insbesondere nicht als Gast und hat damit Anwesenheitsrecht auf der Mitgliederversammlung. Zusätzlich aus Verständlichkeitsgründen nochmal die Formulierung für Beschlussfähigkeit in Abs. 6
- Beschränkung auf ein vertretenes Mitglied pro Repräsentant, um mögliche Stimmenkumulation auf anwesende Mitglieder zu vermeiden, die diese Stimmen in Diskussionen als Druckmittel einsetzen könnten.
- Schriftform (§126 BGB) als brauchbarer Mittelweg, kann auch durch elektronische Übermittlung des Dokuments (Scan per E-Mail, Fax) gewahrt werden. Unter Textform würde z.B. auch IRC fallen, was nicht fälschungssicher genug ist, mündliche Aussagen sind nicht ausreichend nachvollziehbar.
