### PR TITLE
Beitragsordnung: monatliche Beiträge müssen glatte Centbeträge ergeben

### DIFF
--- a/Beitragsordnung.tex
+++ b/Beitragsordnung.tex
@@ -17,6 +17,7 @@
   \item Der reguläre Mitgliedsbeitrag für ordentliche Mitglieder beträgt 20€
     pro Monat. Fördermitglieder zahlen einen frei wählbaren Beitrag von
     mindestens 30€ pro Jahr.
+    Der Jahresbeitrag muss ein Vielfaches von 12 Cent betragen.
   \item Schüler, Studenten, Auszubildende, Empfänger von Sozialgeld oder
     Arbeitslosengeld~II einschließlich Leistungen nach §~22 ohne Zuschläge oder
     nach §~24 des Zweiten Buchs des Sozialgesetzbuchs (SGB~II), sowie Empfänger
@@ -28,6 +29,7 @@
     Mitgliedsbeitrag nicht aufbringen können, kann dieses beim Vorstand einen
     Antrag auf Ermäßigung oder Befreiung stellen. Diese gilt für maximal ein
     Jahr und kann dann durch einen neuen Antrag erneuert werden.
+    Der ermäßigte monatliche Beitrag muss ein glatter Centbetrag sein.
   \item Alle Mitglieder werden ermutigt, im Rahmen ihrer Möglichkeiten eine
     regelmäßige Spende an den Verein zu entrichten. Empfohlen wird eine Spende
     in Höhe von 1\% des Bruttoeinkommens.


### PR DESCRIPTION
Die Sollbuchung des Mitgliedsbeitrags erfolgt im aktuellen Schatzmeister-Workflow monatlich, da dies den kleinsten gemeinsamen Nenner für die Fälligkeit der Beiträge darstellet.  Für den Workflow ist es nicht praktikabel, Fördermitglieder gesondert zu behandeln; Jahresbeiträge werden hierbei auf den entsprechenden monatlichen Anteil umgerechnet.  Diese Regelung soll vermeiden, dass bei dieser Umrechnung Centbeträge mit Nachkommastellen entstehen, die zu Rundungsfehler führen würden, nicht überwiesen werden könnten und zusätzliche Ausgleichsbuchungen erfordern würden.

Ähnliche Formulierung für den ermäßigten Beitrag, nur um auf der sicheren Seite zu sein.
